### PR TITLE
Add MicroBadger badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 [![Docker Pulls](https://img.shields.io/docker/pulls/rubicks/ros-dev.svg)](https://hub.docker.com/r/rubicks/ros-dev/)
-[![Docker Stars](https://img.shields.io/docker/stars/rubicks/ros-dev.svg?style=flat-square)](https://hub.docker.com/r/rubicks/ros-dev/)
+[![Docker Stars](https://img.shields.io/docker/stars/rubicks/ros-dev.svg?style=flat-square)](https://hub.docker.com/r/rubicks/ros-dev/) [![](https://images.microbadger.com/badges/image/rubicks/ros-dev.svg)](https://microbadger.com/images/rubicks/ros-dev "Get your own image badge on microbadger.com")
 
 # ros-dev
 
 A docker image for [ROS][ros] project development.
 
 [ros]:http://www.ros.org/
+ 


### PR DESCRIPTION
We saw your image on Docker Hub at [rubicks/ros-dev](https://hub.docker.com/r/rubicks/ros-dev/), and we thought you might like this badge for your GitHub readme showing the image contents.

The badge shows the number of layers and download size of your Docker image, and links to our site where you can see the [contents of each layer](https://microbadger.com/images/rubicks/ros-dev).

As you're using an automated build it will also show up in your Docker Hub description.

[![](https://images.microbadger.com/badges/image/rubicks/ros-dev.svg)](https://microbadger.com/images/rubicks/ros-dev)
